### PR TITLE
Add pytest-asyncio support for async tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,9 @@ dependencies = [
     "transformers>=4.48.1",
     "uvicorn>=0.35.0",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2.2",
+    "pytest-asyncio>=0.23.5",
+]

--- a/src/test_workflow.py
+++ b/src/test_workflow.py
@@ -4,6 +4,7 @@ Test workflow to verify the core functionality
 import asyncio
 import logging
 import sys
+import pytest
 
 from core.workflow import WorkflowEngine, WorkflowStep
 from core.knowledge_graph import KnowledgeGraph, Node, Edge
@@ -18,6 +19,7 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.asyncio
 async def test_workflow():
     # Initialize components
     logger.info("Initializing workflow components...")


### PR DESCRIPTION
## Summary
- add `pytest` and `pytest-asyncio` as dev dependencies
- mark async test with `pytest.mark.asyncio`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885cb630920832692f01619c095cea2