### PR TITLE
Add unit economics prior to ontology

### DIFF
--- a/knowledge-graph/query-examples.yaml
+++ b/knowledge-graph/query-examples.yaml
@@ -156,3 +156,34 @@ queries:
       cypher: |
         MATCH (v:DigitalVenture)-[:ASSESSED_BY]->(r:RiskProfile)
         RETURN v.business_model, r.risk_level, r.mitigation_strategies;
+  # Query 6: Unit economics screening
+  unit_economics_screen:
+    description: "Filter ventures that meet minimum CTR/CR requirements"
+    pattern:
+      match:
+        venture:
+          type: "DigitalVenture"
+        econ:
+          type: "UnitEconomicsPrior"
+          relationship: "hasUnitEconomicsPrior"
+          source: "venture"
+          properties:
+            expected_ctr: { $gte: "$min_ctr" }
+            expected_cr: { $gte: "$min_cr" }
+      return:
+        - venture.id
+        - venture.name
+        - econ.expected_ctr
+        - econ.expected_cr
+    example_result:
+      ventures:
+        - id: "DV100"
+          name: "High CTR SaaS"
+          expected_ctr: 0.05
+          expected_cr: 0.03
+    example_syntax:
+      cypher: |
+        MATCH (v:DigitalVenture)-[:HAS_UNIT_ECONOMICS_PRIOR]->(e:UnitEconomicsPrior)
+        WHERE e.expected_ctr >= $min_ctr AND e.expected_cr >= $min_cr
+        RETURN v.id, v.name, e.expected_ctr, e.expected_cr;
+

--- a/ontology/ontology-guide.md
+++ b/ontology/ontology-guide.md
@@ -132,7 +132,17 @@ Role → managesEcommerce → EcommerceVenture
 Role → ensuresEcommerceRegulation → EcommerceVenture
 ```
 
+
 3. Content platform connections:
 ```yaml
 Role → structuresContent → ContentPlatform
 Role → promotesContent → ContentPlatform
+```
+
+### UnitEconomicsPrior
+Defines baseline financial assumptions for screening opportunities.
+- **expected_ctr**: Optimistic click-through rate
+- **expected_cr**: Optimistic conversion rate
+- **max_cac**: Maximum customer acquisition cost
+- **min_ltv**: Minimum lifetime value per customer
+- **viability_threshold**: Required profit margin

--- a/ontology/ontology-schema.yaml
+++ b/ontology/ontology-schema.yaml
@@ -32,6 +32,8 @@ classes:
         type: object
       - name: market_segment
         type: object
+      - name: unit_economics_prior
+        type: object
       # New AI-specific properties
       - name: usesAIModule
         type: boolean
@@ -124,6 +126,22 @@ classes:
       - name: growth_potential
         type: number
 
+  UnitEconomicsPrior:
+    description: "Baseline financial assumptions for opportunity screening"
+    properties:
+      - name: id
+        type: string
+      - name: expected_ctr
+        type: number
+      - name: expected_cr
+        type: number
+      - name: max_cac
+        type: number
+      - name: min_ltv
+        type: number
+      - name: viability_threshold
+        type: number
+
 relationships:
   - name: contributesTo
     source: Role
@@ -148,6 +166,11 @@ relationships:
   - name: assessedBy
     source: DigitalVenture
     target: RiskProfile
+    cardinality: "one-to-one"
+
+  - name: hasUnitEconomicsPrior
+    source: DigitalVenture
+    target: UnitEconomicsPrior
     cardinality: "one-to-one"
 
   - name: implementsAI


### PR DESCRIPTION
## Summary
- add `unit_economics_prior` field in ontology schema and define `UnitEconomicsPrior` class
- document the new class in `ontology-guide.md`
- update knowledge graph queries with unit economics screening example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885e62a85948326976da66937f04e84