### PR TITLE
Add phase manager and portfolio reporting to Wealth Machine orchestrator

### DIFF
--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from ..agents.specialized import (
     BusinessModelInnovatorAgent,
@@ -18,6 +18,7 @@ from ..agents.specialized import (
 from ..core.loops import IncomeStreamsLoop, TeamLoop
 from ..core.performance import PerformanceTracker, SMARTGoal
 from ..services.decision_engine import DecisionEngine
+from ..services.phase_management import PhaseManager
 from ..services.risk_management import RiskManager
 
 
@@ -29,6 +30,7 @@ class WealthMachineOrchestrator:
         decision_engine: Optional[DecisionEngine] = None,
         risk_manager: Optional[RiskManager] = None,
         performance_tracker: Optional[PerformanceTracker] = None,
+        phase_manager: Optional[PhaseManager] = None,
     ) -> None:
         self.agents = {
             "emerging_tech": EmergingTechAgent("agent-emerging-tech"),
@@ -46,6 +48,7 @@ class WealthMachineOrchestrator:
 
         self.decision_engine = decision_engine or DecisionEngine([])
         self.risk_manager = risk_manager or RiskManager()
+        self.phase_manager = phase_manager or PhaseManager()
 
         self.income_loop = IncomeStreamsLoop(
             self.agents,
@@ -77,9 +80,20 @@ class WealthMachineOrchestrator:
         cycle_result = await self.income_loop.execute_cycle(venture_id, payload)
         team_result = await self.team_loop.execute_cycle(cycle_result)
 
+        phase_decision = self.phase_manager.record_cycle(
+            venture_id,
+            metrics={
+                "opportunity_score": cycle_result.opportunity.data.get("opportunity_score", 0.0),
+                "expected_roi": cycle_result.financial.data.get("expected_roi", 0.0),
+            },
+            risk_level=cycle_result.risk.get("risk_level", "Moderate"),
+        )
+
         return {
             "venture": cycle_result.as_dict(),
             "team": team_result.as_dict(),
+            "phase": phase_decision.as_dict(),
+            "portfolio": self.phase_manager.portfolio_summary(),
         }
 
 

--- a/src/services/phase_management.py
+++ b/src/services/phase_management.py
@@ -1,0 +1,160 @@
+"""Phase management utilities for orchestrating venture scale."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+RISK_ORDER = ["Ultra Low", "Low", "Moderate", "High", "Very High"]
+
+
+@dataclass
+class PhaseGate:
+    """Represents a single phase with entry criteria and guardrails."""
+
+    name: str
+    minimum_opportunity_score: float
+    minimum_expected_roi: float
+    maximum_risk_level: str
+    reinvestment_rate: float
+    description: str = ""
+
+    def allows(self, metrics: Dict[str, Any], risk_level: str) -> bool:
+        """Return True if metrics satisfy the gate criteria."""
+
+        risk_level = risk_level or "Moderate"
+        try:
+            current_risk_rank = RISK_ORDER.index(risk_level)
+        except ValueError:
+            current_risk_rank = len(RISK_ORDER) - 1
+        risk_ok = current_risk_rank <= RISK_ORDER.index(self.maximum_risk_level)
+        return (
+            metrics.get("opportunity_score", 0.0) >= self.minimum_opportunity_score
+            and metrics.get("expected_roi", 0.0) >= self.minimum_expected_roi
+            and risk_ok
+        )
+
+
+@dataclass
+class PhaseDecision:
+    """Outcome of evaluating a venture against the phase gates."""
+
+    venture_id: str
+    current_phase: str
+    decision: str
+    reinvestment_rate: float
+    next_phase: Optional[str] = None
+    reasons: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "venture_id": self.venture_id,
+            "current_phase": self.current_phase,
+            "next_phase": self.next_phase,
+            "decision": self.decision,
+            "reinvestment_rate": round(self.reinvestment_rate, 3),
+            "reasons": list(self.reasons),
+        }
+
+
+class PhaseManager:
+    """Determines how ventures progress across phases 1–3."""
+
+    def __init__(self, phases: Optional[List[PhaseGate]] = None) -> None:
+        self.phases = phases or [
+            PhaseGate(
+                name="Phase 1: Explore",
+                minimum_opportunity_score=0.45,
+                minimum_expected_roi=0.25,
+                maximum_risk_level="High",
+                reinvestment_rate=0.2,
+                description="Small, low-risk experiments",
+            ),
+            PhaseGate(
+                name="Phase 2: Validate",
+                minimum_opportunity_score=0.6,
+                minimum_expected_roi=0.45,
+                maximum_risk_level="Moderate",
+                reinvestment_rate=0.35,
+                description="Validated bets ready for structured pilots",
+            ),
+            PhaseGate(
+                name="Phase 3: Scale",
+                minimum_opportunity_score=0.7,
+                minimum_expected_roi=0.7,
+                maximum_risk_level="Low",
+                reinvestment_rate=0.5,
+                description="Scaling portfolio with disciplined reinvestment",
+            ),
+        ]
+        self._venture_phase: Dict[str, str] = {}
+        self._history: Dict[str, List[PhaseDecision]] = {}
+
+    def _current_index(self, venture_id: str) -> int:
+        current = self._venture_phase.get(venture_id, self.phases[0].name)
+        for idx, phase in enumerate(self.phases):
+            if phase.name == current:
+                return idx
+        return 0
+
+    def record_cycle(self, venture_id: str, metrics: Dict[str, Any], risk_level: str) -> PhaseDecision:
+        """Evaluate a venture and return the recommended phase posture."""
+
+        current_index = self._current_index(venture_id)
+        current_phase = self.phases[current_index]
+        reasons: List[str] = []
+        decision = "stabilize"
+        next_phase: Optional[str] = None
+
+        # Promotion logic
+        if current_index + 1 < len(self.phases):
+            candidate_phase = self.phases[current_index + 1]
+            if candidate_phase.allows(metrics, risk_level):
+                decision = "promote"
+                next_phase = candidate_phase.name
+                self._venture_phase[venture_id] = candidate_phase.name
+                reasons.append("Metrics satisfy next phase gate")
+
+        # Regression logic if risk is too high for current phase
+        if decision == "stabilize" and not current_phase.allows(metrics, risk_level) and current_index > 0:
+            previous_phase = self.phases[current_index - 1]
+            decision = "regress"
+            next_phase = previous_phase.name
+            self._venture_phase[venture_id] = previous_phase.name
+            reasons.append("Risk or metrics breached current gate")
+
+        # Maintain current state if no transition occurred
+        if self._venture_phase.get(venture_id) is None:
+            self._venture_phase[venture_id] = current_phase.name
+
+        reinvestment_rate = self.phases[self._current_index(venture_id)].reinvestment_rate
+        outcome = PhaseDecision(
+            venture_id=venture_id,
+            current_phase=current_phase.name,
+            decision=decision,
+            reinvestment_rate=reinvestment_rate,
+            next_phase=next_phase,
+            reasons=reasons,
+        )
+        self._history.setdefault(venture_id, []).append(outcome)
+        return outcome
+
+    def portfolio_summary(self) -> Dict[str, Any]:
+        """Return current phase posture and last decision per venture."""
+
+        return {
+            venture_id: {
+                "phase": self._venture_phase.get(venture_id, self.phases[0].name),
+                "last_decision": self._history[venture_id][-1].as_dict() if self._history.get(venture_id) else None,
+            }
+            for venture_id in self._venture_phase
+        }
+
+    def history(self, venture_id: str) -> List[Dict[str, Any]]:
+        """Return serialised decision history for a venture."""
+
+        return [decision.as_dict() for decision in self._history.get(venture_id, [])]
+
+
+__all__ = ["PhaseGate", "PhaseDecision", "PhaseManager"]

--- a/tests/test_orchestrator_loops.py
+++ b/tests/test_orchestrator_loops.py
@@ -41,6 +41,13 @@ def test_income_stream_cycle_generates_cohesive_plan() -> None:
     first_agent_snapshot = next(iter(team["performance_snapshots"].values()))
     assert first_agent_snapshot["goals"], "Performance tracker must return goal snapshots"
 
+    phase = report["phase"]
+    assert phase["decision"] in {"promote", "stabilize", "regress"}
+    assert "Phase" in phase["current_phase"]
+
+    portfolio = report["portfolio"]
+    assert "venture-async-1" in portfolio
+
 
 def test_orchestrator_runs_sync_event_loop() -> None:
     orchestrator = WealthMachineOrchestrator()
@@ -57,4 +64,4 @@ def test_orchestrator_runs_sync_event_loop() -> None:
         report = loop.run_until_complete(_run())
     finally:
         loop.close()
-    assert set(report.keys()) == {"venture", "team"}
+    assert set(report.keys()) == {"venture", "team", "phase", "portfolio"}

--- a/tests/test_phase_management.py
+++ b/tests/test_phase_management.py
@@ -1,0 +1,69 @@
+from src.services.phase_management import PhaseGate, PhaseManager
+
+
+def test_phase_manager_promotes_and_regresses_based_on_metrics() -> None:
+    manager = PhaseManager()
+
+    strong_metrics = {"opportunity_score": 0.75, "expected_roi": 0.8}
+    decision1 = manager.record_cycle("venture-1", strong_metrics, risk_level="Low")
+    assert decision1.decision == "promote"
+    assert decision1.next_phase == "Phase 2: Validate"
+
+    stronger_metrics = {"opportunity_score": 0.8, "expected_roi": 0.9}
+    decision2 = manager.record_cycle("venture-1", stronger_metrics, risk_level="Ultra Low")
+    assert decision2.decision in {"promote", "stabilize"}
+    assert manager.portfolio_summary()["venture-1"]["phase"] in {"Phase 2: Validate", "Phase 3: Scale"}
+
+    risky_metrics = {"opportunity_score": 0.4, "expected_roi": 0.2}
+    decision3 = manager.record_cycle("venture-1", risky_metrics, risk_level="Very High")
+    assert decision3.decision in {"regress", "stabilize"}
+    assert manager.portfolio_summary()["venture-1"]["phase"] in {"Phase 1: Explore", "Phase 2: Validate"}
+
+
+def test_custom_phase_gate_can_lower_thresholds() -> None:
+    experimental_phase = PhaseGate(
+        name="Phase 0: Incubate",
+        minimum_opportunity_score=0.2,
+        minimum_expected_roi=0.1,
+        maximum_risk_level="Very High",
+        reinvestment_rate=0.1,
+        description="Tiny experiments to spin up the loop quickly",
+    )
+    manager = PhaseManager(phases=[experimental_phase] + manager_phases())
+
+    decision = manager.record_cycle(
+        "venture-2",
+        metrics={"opportunity_score": 0.25, "expected_roi": 0.15},
+        risk_level="High",
+    )
+    assert decision.decision in {"stabilize", "promote"}
+    assert decision.reinvestment_rate == experimental_phase.reinvestment_rate
+
+
+def manager_phases():
+    return [
+        PhaseGate(
+            name="Phase 1: Explore",
+            minimum_opportunity_score=0.45,
+            minimum_expected_roi=0.25,
+            maximum_risk_level="High",
+            reinvestment_rate=0.2,
+            description="Small, low-risk experiments",
+        ),
+        PhaseGate(
+            name="Phase 2: Validate",
+            minimum_opportunity_score=0.6,
+            minimum_expected_roi=0.45,
+            maximum_risk_level="Moderate",
+            reinvestment_rate=0.35,
+            description="Validated bets ready for structured pilots",
+        ),
+        PhaseGate(
+            name="Phase 3: Scale",
+            minimum_opportunity_score=0.7,
+            minimum_expected_roi=0.7,
+            maximum_risk_level="Low",
+            reinvestment_rate=0.5,
+            description="Scaling portfolio with disciplined reinvestment",
+        ),
+    ]


### PR DESCRIPTION
## Summary
- add a reusable phase management service that governs promotion, regression, and reinvestment decisions across phases
- extend the orchestrator cycle report with phase decisions and portfolio posture to connect the income and team loops to phase gates
- add coverage for the new phase logic and updated orchestrator outputs

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949323429c88326ac47597a08c9204a)