### PR TITLE
Add Network wealth engine orchestration and tests

### DIFF
--- a/src/network_my_networth/__init__.py
+++ b/src/network_my_networth/__init__.py
@@ -1,0 +1,10 @@
+"""Network My Net Worth package.
+
+Provides orchestration helpers that combine the Income Streams and
+Team loops, risk management, decision rules, and SMART goal tracking
+into a cohesive, locally runnable application.
+"""
+
+from .system import NetworkWealthEngine, PortfolioRunResult
+
+__all__ = ["NetworkWealthEngine", "PortfolioRunResult"]

--- a/src/network_my_networth/system.py
+++ b/src/network_my_networth/system.py
@@ -1,0 +1,139 @@
+"""End-to-end orchestration for the "My Network" wealth engine.
+
+The :class:`NetworkWealthEngine` class wires together the Income Streams
+Loop and Team Loop, the risk manager, decision rules, and phase gates so
+that a local operator can simulate how a portfolio of ventures would be
+sourced, validated, launched, and continuously improved.
+
+The design intentionally mirrors the master plan:
+
+* Specialized agents from :mod:`src.agents.specialized` scout
+  opportunities, validate markets, design products, and handle go-to-
+  market and partnerships.
+* The Income Streams Loop turns raw signals into a coherent venture plan
+  with ROI, risk, and go/no-go recommendations.
+* The Team Loop shares insights back across the network while updating
+  SMART goal progress so performance compounds over time.
+* The risk manager and rule engine enforce guardrails, while the
+  :class:`~src.services.phase_management.PhaseManager` scales ventures
+  through phases 1–3 with explicit reinvestment controls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+from src.core.knowledge_graph_connector import KnowledgeGraphConnector
+from src.core.performance import PerformanceTracker, SMARTGoal
+from src.services.decision_engine import (
+    ActionSpec,
+    ConditionNode,
+    DecisionEngine,
+    Operator,
+    Rule,
+)
+from src.services.orchestrator import WealthMachineOrchestrator
+from src.services.phase_management import PhaseManager
+from src.services.risk_management import RiskManager
+
+
+@dataclass
+class PortfolioRunResult:
+    """Container capturing the outcome of a portfolio-wide simulation."""
+
+    ventures: Dict[str, Dict[str, Any]]
+    portfolio_summary: Dict[str, Any]
+    performance_report: Dict[str, Any]
+
+
+class NetworkWealthEngine:
+    """High-level facade that operationalises the master plan."""
+
+    def __init__(
+        self,
+        rules_path: Optional[str] = None,
+        rules: Optional[Iterable[Rule]] = None,
+        performance_tracker: Optional[PerformanceTracker] = None,
+        phase_manager: Optional[PhaseManager] = None,
+        connector: Optional[KnowledgeGraphConnector] = None,
+    ) -> None:
+        self.connector = connector or KnowledgeGraphConnector()
+        self.performance_tracker = performance_tracker or PerformanceTracker()
+        self.phase_manager = phase_manager or PhaseManager()
+
+        if rules is not None:
+            rule_list = list(rules)
+            self.decision_engine = DecisionEngine(rule_list, connector=self.connector)
+        elif rules_path:
+            self.decision_engine = DecisionEngine.from_json_file(rules_path, connector=self.connector)
+        else:
+            self.decision_engine = DecisionEngine([], connector=self.connector)
+
+        self.risk_manager = RiskManager(connector=self.connector)
+        self.orchestrator = WealthMachineOrchestrator(
+            decision_engine=self.decision_engine,
+            risk_manager=self.risk_manager,
+            performance_tracker=self.performance_tracker,
+            phase_manager=self.phase_manager,
+        )
+
+    def register_goal(self, goal: SMARTGoal) -> SMARTGoal:
+        """Register a SMART goal for any agent in the network."""
+
+        return self.performance_tracker.register_goal(goal)
+
+    async def run_venture(self, venture_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute both loops for a single venture asynchronously."""
+
+        return await self.orchestrator.run_income_stream_cycle(venture_id, payload)
+
+    def run_venture_sync(self, venture_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Synchronous wrapper for environments without an event loop."""
+
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(self.run_venture(venture_id, payload))
+        finally:
+            loop.close()
+
+    def run_portfolio(self, ventures: Mapping[str, Dict[str, Any]]) -> PortfolioRunResult:
+        """Run a full cycle across multiple ventures."""
+
+        reports: Dict[str, Dict[str, Any]] = {}
+        for venture_id, payload in ventures.items():
+            reports[venture_id] = self.run_venture_sync(venture_id, payload)
+
+        return PortfolioRunResult(
+            ventures=reports,
+            portfolio_summary=self.phase_manager.portfolio_summary(),
+            performance_report=self.performance_tracker.generate_report(),
+        )
+
+    @staticmethod
+    def build_risk_rule(rule_id: str = "risk_guardrail", threshold: float = 0.65) -> Rule:
+        """Convenience helper to create a risk-based decision rule."""
+
+        condition = ConditionNode(
+            metric="risk_score",
+            comparator=Operator.GREATER_THAN,
+            value=threshold,
+        )
+        action = ActionSpec(
+            type="update_venture_status",
+            parameters={
+                "new_status": "High Risk",
+                "notify_roles": ["RiskManager"],
+            },
+        )
+        return Rule(
+            rule_id=rule_id,
+            name="Risk Threshold Guardrail",
+            venture_type="DigitalVenture",
+            condition=condition,
+            action=action,
+        )
+
+
+__all__ = ["NetworkWealthEngine", "PortfolioRunResult"]

--- a/tests/test_network_my_networth.py
+++ b/tests/test_network_my_networth.py
@@ -1,0 +1,64 @@
+from typing import Dict
+
+from src.network_my_networth import NetworkWealthEngine
+
+
+def test_portfolio_run_creates_reports() -> None:
+    engine = NetworkWealthEngine(rules_path="automation/sample-rules.json")
+
+    ventures: Dict[str, Dict[str, object]] = {
+        "venture-alpha": {
+            "technology_signals": [
+                {"name": "Edge AI", "impact": 0.82, "maturity": 0.75, "theme": "AI"},
+                {"name": "Automation", "impact": 0.78, "maturity": 0.7, "theme": "Ops"},
+            ],
+            "market_data": {"demand_index": 0.68, "growth_rate": 0.08, "competition_index": 0.4},
+            "business_model": {"base_price": 119.0},
+            "financial": {"minimum_roi": 0.6},
+            "personas": ["Builders", "Operators"],
+        },
+        "venture-beta": {
+            "technology_signals": [
+                {"name": "Fintech APIs", "impact": 0.7, "maturity": 0.65, "theme": "Fintech"},
+            ],
+            "market_data": {"demand_index": 0.6, "growth_rate": 0.07, "competition_index": 0.5},
+            "business_model": {"base_price": 89.0},
+            "financial": {"minimum_roi": 0.55},
+            "personas": ["Founders"],
+            "industry": "fintech",
+            "jurisdictions": ["US", "EU"],
+        },
+    }
+
+    result = engine.run_portfolio(ventures)
+
+    assert set(result.ventures.keys()) == set(ventures.keys())
+    for report in result.ventures.values():
+        venture = report["venture"]
+        assert venture["go_no_go"] in {"go", "defer"}
+        assert "risk" in venture
+        assert report["team"]["insights"], "Team loop should generate insights for each venture"
+        assert report["phase"]["decision"] in {"promote", "stabilize", "regress"}
+
+    assert result.portfolio_summary, "Portfolio summary should be populated"
+    assert result.performance_report.get("goals"), "SMART goal report should include goals"
+
+
+def test_custom_rule_triggers_decision_outcome() -> None:
+    risk_rule = NetworkWealthEngine.build_risk_rule(threshold=0.1)
+    engine = NetworkWealthEngine(rules=[risk_rule])
+
+    payload = {
+        "technology_signals": [],
+        "market_data": {"demand_index": 0.5, "growth_rate": 0.04, "competition_index": 0.55},
+        "financial": {"minimum_roi": 0.2},
+        "minimum_opportunity_score": 0.2,
+    }
+
+    report = engine.run_venture_sync("venture-risky", payload)
+    decisions = report["venture"]["decision_outcomes"]
+
+    assert decisions, "Decision engine should produce outcomes when guardrails trigger"
+    assert any(outcome.get("action_type") == "update_venture_status" for outcome in decisions)
+    assert report["venture"]["risk"]["risk_level"] in {"Ultra Low", "Low", "Moderate", "High", "Very High"}
+    assert report["team"]["performance_snapshots"]


### PR DESCRIPTION
## Summary
- add the NetworkWealthEngine facade to orchestrate income and team loops with decision rules, risk management, and phase gates
- provide a reusable risk guardrail rule helper and portfolio run container for the wealth engine
- add tests covering portfolio simulations and decision-engine guardrail triggering

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694936a041248326a90c785bda483818)